### PR TITLE
add issue template for incoming data request

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_data.md
+++ b/.github/ISSUE_TEMPLATE/request_data.md
@@ -1,0 +1,26 @@
+---
+name: Request data from other subsystem(s)
+about: >
+  Announce that your device our subsystem requires data from other subsystems
+  which is not yet covered by existing CSMIM object types
+labels: enhancement
+---
+
+
+**Request summary:**
+For which kind of equipment and intended usage do you need additional data?
+
+**ATA Chapter:**
+(of your subsystem) e.g. 33-20 Lights / Passenger Compartment
+
+**Security Domain:**
+(of your subsystem) e.g. core, crew, pax, ife
+
+**Existing Types:**
+List existing types if they are related but fail to meet your needs.
+
+**Required data:**
+
+List the additional data that you require to be published by other subsystems.
+Add requirements on accuracy or frequency if these are important or not
+provided by the existing object types.

--- a/.github/ISSUE_TEMPLATE/request_data.md
+++ b/.github/ISSUE_TEMPLATE/request_data.md
@@ -1,7 +1,7 @@
 ---
 name: Request data from other subsystem(s)
 about: >
-  Announce that your device our subsystem requires data from other subsystems
+  Announce that your device or subsystem requires data from other subsystems
   which is not yet covered by existing CSMIM object types
 labels: enhancement
 ---
@@ -14,13 +14,17 @@ For which kind of equipment and intended usage do you need additional data?
 (of your subsystem) e.g. 33-20 Lights / Passenger Compartment
 
 **Security Domain:**
-(of your subsystem) e.g. core, crew, pax, ife
+(of your subsystem) e.g. crew, pax
 
 **Existing Types:**
 List existing types if they are related but fail to meet your needs.
 
 **Required data:**
-
 List the additional data that you require to be published by other subsystems.
-Add requirements on accuracy or frequency if these are important or not
-provided by the existing object types.
+
+ - [ ] title of requested data item 1
+ - [ ] title of requested data item 2
+
+Elaborate on your list and possible sources.
+Add requirements on accuracy or frequency if relevant to you.
+

--- a/.github/ISSUE_TEMPLATE/request_data.md
+++ b/.github/ISSUE_TEMPLATE/request_data.md
@@ -20,11 +20,11 @@ For which kind of equipment and intended usage do you need additional data?
 List existing types if they are related but fail to meet your needs.
 
 **Required data:**
-List the additional data that you require to be published by other subsystems.
+List the additional data items that you require to be published by other 
+subsystems.
 
- - [ ] title of requested data item 1
- - [ ] title of requested data item 2
+ - [ ] requested data item 1
+ - [ ] requested data item 2
 
 Elaborate on your list and possible sources.
 Add requirements on accuracy or frequency if relevant to you.
-


### PR DESCRIPTION
As requested by the CSMIM working group, here is a new issue template that could be used for requesting that other systems send data that is required by the issuer's system. For cases like in issue #9.