### PR TITLE
Test for PR #40: duplicate attribute warning action

### DIFF
--- a/types/csmim.obj.test-duplicate-warning.1.yaml
+++ b/types/csmim.obj.test-duplicate-warning.1.yaml
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+id: csmim.obj.test-duplicate-warning.1
+description: Temporary type to test duplicate attribute warnings in PR #40.
+
+attributes:
+  - key: mfr
+    description: Duplicate manufacturer attribute for GitHub Actions testing.
+
+resources: []

--- a/types/csmim.obj.test-duplicate-warning.1.yaml
+++ b/types/csmim.obj.test-duplicate-warning.1.yaml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 id: csmim.obj.test-duplicate-warning.1
-description: Temporary type to test duplicate attribute warnings in PR #40.
+description: "Temporary type to test duplicate attribute warnings in PR #40."
 
 attributes:
   - key: mfr

--- a/types/csmim.obj.test-duplicate-warning.1.yaml
+++ b/types/csmim.obj.test-duplicate-warning.1.yaml
@@ -1,10 +1,29 @@
 %YAML 1.2
 ---
 id: csmim.obj.test-duplicate-warning.1
-description: "Temporary type to test duplicate attribute warnings in PR #40."
+supertypes:
+  - csmim.obj.seat.1
+description: Temporary type to test duplicate ID warnings in PR 40.
 
 attributes:
   - key: mfr
     description: Duplicate manufacturer attribute for GitHub Actions testing.
 
-resources: []
+resources:
+  - id: safe_for_ttl
+    mode: r
+    type: bool
+    description: Duplicate resource inherited from a supertype.
+
+  - id: motion
+    mode: r
+    type: bool
+    description: Duplicate resource from unrelated existing types.
+
+  - id: movement_status  # duplicate ok: intentional test suppression
+    mode: r
+    type: enum
+    description: Suppressed duplicate resource from an existing type.
+    enum-values:
+      - name: stopped
+        key: 1


### PR DESCRIPTION
Draft PR to test the GitHub Actions integration added in PR #40.

This intentionally adds a temporary type with a duplicate `mfr` attribute so the advisory duplicate-attribute warning step should emit a GitHub Actions warning annotation while the hard syntax checks remain green.