### PR TITLE
fix example object type names in directory service

### DIFF
--- a/types/csmim.obj.directory.1.yaml
+++ b/types/csmim.obj.directory.1.yaml
@@ -44,11 +44,11 @@ resources:
 
       Example: Some CSMIM endpoint registers a new object under the path
       "crew/galley/x5" with the object type "csmim.obj.galley.1" and the
-      supertype "csmim.obj.fault-report.1". That supertype has been configured
+      supertype "csmim.obj.bite-reporter.1". That supertype has been configured
       as a type of interest. Then, the directory service will publish a message
-      at the path "core/csmim/directory/csmim.obj/fault-report.1/crew/galley/x5"
-      with the payload ["csmim.obj.galley.1","csmim.obj.fault-report.1"].
+      at "core/csmim/directory/csmim.obj/bite-reporter.1/crew/galley/x5"
+      with the payload ["csmim.obj.galley.1","csmim.obj.bite-reporter.1"].
 
-      A client that wants to be informed about all objects that are derived from
-      "csmim.obj.fault-report.1" can subscribe the path
-      "core/csmim/directory/csmim.obj/fault-report.1/#".
+      A client that wants to be informed about all objects that are derived
+      from "csmim.obj.bite-reporter.1" can subscribe the path
+      "core/csmim/directory/csmim.obj/bite-reporter.1/#".


### PR DESCRIPTION
The directory service type `csmim.obj.directory.1` used the old type name `csmim.obj.fault-report.1` in its documentation. This PR replaces that by the actually existing `csmim.obj.bite-reporter.1` for clarity.